### PR TITLE
✨  sandboxd (ruby, python); brew prefix => ~1.13s [build]

### DIFF
--- a/config/git.completion.zsh
+++ b/config/git.completion.zsh
@@ -1,7 +1,8 @@
 # Uses git's autocompletion for inner commands. Assumes an install of git's
 # bash `git-completion` script at $completion below (this is where Homebrew
 # tosses it, at least).
-completion='$(brew --prefix)/share/zsh/site-functions/_git'
+
+completion='$BREW_PREFIX/share/zsh/site-functions/_git'usr/local
 
 if test -f $completion
 then

--- a/config/nvm.completion.zsh
+++ b/config/nvm.completion.zsh
@@ -1,2 +1,2 @@
 # nvm: completions
-[ -s "$(brew --prefix)/opt/nvm/etc/bash_completion.d/nvm" ] && . "$(brew --prefix)/opt/nvm/etc/bash_completion.d/nvm"
+[ -s "$BREW_PREFIX/opt/nvm/etc/bash_completion.d/nvm" ] && . "$BREW_PREFIX/opt/nvm/etc/bash_completion.d/nvm"

--- a/config/python.path.zsh
+++ b/config/python.path.zsh
@@ -1,13 +1,1 @@
-if (( $+commands[pyenv] )); then
-  export PYENV_ROOT="$HOME/.pyenv"
-  export PATH="$PYENV_ROOT/bin:$PATH"
-  eval "$(pyenv init --path)"
-  eval "$(pyenv init -)"
-fi
-
-if (( $+commands[pyenv-virtualenv-init] )); then
-  eval "$(pyenv virtualenv-init -)"
-fi
-
-# Disable python virtualenv environment prompt prefix
-export VIRTUAL_ENV_DISABLE_PROMPT=true
+# 🚚️ moved to: sandboxrc.symlink

--- a/config/ruby.completion.zsh
+++ b/config/ruby.completion.zsh
@@ -1,5 +1,5 @@
-# Stolen from
-#   https://github.com/sstephenson/rbenv/blob/master/completions/rbenv.zsh
+# (c) @sstephenson
+# ref:  https://github.com/sstephenson/rbenv/blob/master/completions/rbenv.zsh
 
 if [[ ! -o interactive ]]; then
     return

--- a/config/system.grc.zsh
+++ b/config/system.grc.zsh
@@ -1,5 +1,5 @@
 # GRC colorizes nifty unix tools all over the place
 if (( $+commands[grc] )) && (( $+commands[brew] ))
 then
-  source `brew --prefix`/etc/grc.bashrc
+  source $BREW_PREFIX/etc/grc.bashrc
 fi

--- a/symlinks/rbenv.zsh
+++ b/symlinks/rbenv.zsh
@@ -1,5 +1,1 @@
-# init according to man page
-if (( $+commands[rbenv] ))
-then
-  eval "$(rbenv init -)"
-fi
+# 🚚️ moved to: sandboxrc.symlink

--- a/symlinks/sandboxrc.symlink
+++ b/symlinks/sandboxrc.symlink
@@ -1,0 +1,23 @@
+sandbox_init_pyenv() {
+  if (( $+commands[pyenv] )); then
+    export PYENV_ROOT="$HOME/.pyenv"
+    export PATH="$PYENV_ROOT/bin:$PATH"
+    eval "$(pyenv init --path)"
+    eval "$(pyenv init -)"
+  fi
+
+  if (( $+commands[pyenv-virtualenv-init] )); then
+    eval "$(pyenv virtualenv-init -)"
+  fi
+}
+
+sandbox_init_ruby() {
+  if (( $+commands[rbenv] ))
+  then
+    eval "$(rbenv init -)"
+  fi
+}
+
+sandbox_hook_shims ruby "$HOME/.rbenv/shims"
+sandbox_hook_shims pyenv # "$HOME/.pyenv/shims"
+

--- a/symlinks/zshrc.symlink
+++ b/symlinks/zshrc.symlink
@@ -1,42 +1,41 @@
-# shortcut to this dotfiles path is $ZSH
+# 🍰️ shortcut to this dotfiles path is $ZSH
 export ZSH=$HOME/.dotfiles
-
-# your project folder that we can `c [tab]` to
+export BREW_PREFIX=/usr/local
+# ⚛️ `c [tab]` project folder (move to private?)
 export PROJECTS=~/Code
 
 DEFAULT_USER=`whoami`
 
-autoload -Uz compinit && compinit
+# 🥪️ load sandboxd first
+source $ZSH/zsh/plugins/sandboxd.plugin.zsh
 
-# Stash your environment variables in ~/.zshrc.private. This means they'll stay out
-# of your main dotfiles repository (which may be public, like this one), but
-# you'll have access to them in your scripts.
+# ⚗️ debugging
+# zmodload zsh/zprof
+
+# 🔒️ private `./dotfiles-private` repo stuff
 if [[ -a ~/.zshrc.private ]]
 then
   source ~/.zshrc.private
 fi
 
-# all of our zsh files
+# 💽️ get all zsh files
 typeset -U config_files
 config_files=($ZSH/**/*.zsh)
 
-# load the path files
-# echo "> !* path"
+# 🗺️ load: path
 for file in ${(M)config_files:#*/*.path.zsh}
 do
   source $file
 done
 
-# load everything but the path and completion files
-# echo "> * !*.path|*.completion|nvm.*"
-for file in ${${config_files:#*/*.path.zsh}:#*/*.completion.zsh}
+# 🛁️ load: everything (except: path, completion, & sandboxd)
+for file in ${${${config_files:#*/*.path.zsh}:#*/*.completion.zsh}:#*/sandboxd.plugin.zsh}
 do
-  # echo $file
   source $file
 done
 
-# load every completion after autocomplete loads
-# echo "> completion !*"
+# 🧭️ load: completion (after autocomplete loads)
+autoload -Uz compinit && compinit
 for file in ${(M)config_files:#*/*.completion.zsh}
 do
   source $file
@@ -44,7 +43,7 @@ done
 
 unset config_files
 
-# Better history
+# 📜️ Better history
 # Credits to https://coderwall.com/p/jpj_6q/zsh-better-history-searching-with-arrow-keys
 autoload -U up-line-or-beginning-search
 autoload -U down-line-or-beginning-search
@@ -52,3 +51,6 @@ zle -N up-line-or-beginning-search
 zle -N down-line-or-beginning-search
 bindkey "^[[A" up-line-or-beginning-search # Up
 bindkey "^[[B" down-line-or-beginning-search # Down
+
+# ⚗️ debugging
+# zprof

--- a/zsh/fpath.zsh
+++ b/zsh/fpath.zsh
@@ -1,2 +1,4 @@
-#add each topic folder to fpath so that they can add functions and completion scripts
-for topic_folder ($ZSH/*) if [ -d $topic_folder ]; then  fpath=($topic_folder $fpath); fi;
+# #add each topic folder to fpath so that they can add functions and completion scripts
+# for topic_folder ($ZSH/*) if [ -d $topic_folder ]; then  fpath=($topic_folder $fpath); fi;
+
+# @todo() should be altered to `./config` w/ exceptions

--- a/zsh/plugins/history-substring-search.plugin.zsh
+++ b/zsh/plugins/history-substring-search.plugin.zsh
@@ -1,4 +1,13 @@
+# Bind terminal-specific up and down keys
 
+if [[ -n "$terminfo[kcuu1]" ]]; then
+  bindkey -M emacs "$terminfo[kcuu1]" history-substring-search-up
+  bindkey -M viins "$terminfo[kcuu1]" history-substring-search-up
+fi
+if [[ -n "$terminfo[kcud1]" ]]; then
+  bindkey -M emacs "$terminfo[kcud1]" history-substring-search-down
+  bindkey -M viins "$terminfo[kcud1]" history-substring-search-down
+fi
 
 # Bind terminal-specific up and down keys
 
@@ -11,8 +20,6 @@ if [[ -n "$terminfo[kcud1]" ]]; then
   bindkey -M viins "$terminfo[kcud1]" history-substring-search-down
 fi
 
-
-
 # Bind terminal-specific up and down keys
 
 if [[ -n "$terminfo[kcuu1]" ]]; then
@@ -23,17 +30,3 @@ if [[ -n "$terminfo[kcud1]" ]]; then
   bindkey -M emacs "$terminfo[kcud1]" history-substring-search-down
   bindkey -M viins "$terminfo[kcud1]" history-substring-search-down
 fi
-
-
-
-# Bind terminal-specific up and down keys
-
-if [[ -n "$terminfo[kcuu1]" ]]; then
-  bindkey -M emacs "$terminfo[kcuu1]" history-substring-search-up
-  bindkey -M viins "$terminfo[kcuu1]" history-substring-search-up
-fi
-if [[ -n "$terminfo[kcud1]" ]]; then
-  bindkey -M emacs "$terminfo[kcud1]" history-substring-search-down
-  bindkey -M viins "$terminfo[kcud1]" history-substring-search-down
-fi
-

--- a/zsh/plugins/sandboxd.plugin.zsh
+++ b/zsh/plugins/sandboxd.plugin.zsh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+#
+# (c) @benvan
+# ref: https://github.com/benvan/sandboxd
+#
+
+function sandbox_get_config_file() {
+  if  ! [ -z ${SANDBOXRC+x} ]; then
+    echo "$SANDBOXRC"
+  elif [ -d ${XDG_CONFIG_HOME:-$HOME/.config}/sandboxd ]; then
+    echo "${XDG_CONFIG_HOME:-$HOME/.config}/sandboxd/sandboxrc"
+  else
+    echo "${HOME}/.sandboxrc"
+  fi
+}
+
+typeset -r RC_FILE="$(sandbox_get_config_file)"
+
+# holds all hook descriptions in "cmd:hook" format
+sandbox_hooks=()
+
+# deletes all hooks associated with cmd
+function sandbox_delete_hooks(){
+  local cmd=$1
+  for i in "${sandbox_hooks[@]}";
+  do
+    if [[ $i == "${cmd}:"* ]]; then
+     local hook=$(echo $i | sed "s/.*://")
+     # Check if this is still a function, as it could have been unset alrady in case of duplicates.
+     typeset -f "$hook" >/dev/null && unset -f "$hook"
+    fi
+  done
+}
+
+
+# prepares environment and removes hooks
+function sandbox(){
+  local cmd=$1
+
+   if [[ "$(type $cmd | GREP_OPTIONS= grep -o function)" = "function" ]]; then
+    (>&2 echo "🥪️ sandboxing $cmd ...")
+    sandbox_delete_hooks $cmd
+    sandbox_init_$cmd # run user-defined sandbox
+  else
+    (>&2 echo "🥪️ sandbox '$cmd' not found.\nHave you defined sandbox_init_$cmd(){ ... } in your sandboxrc (${RC_FILE})?")
+    return 1
+  fi
+}
+
+# adds hooks to sandboxes
+function sandbox_hook(){
+  local cmd=$1
+  local hook=$2
+
+  sandbox_hooks+=( "${cmd}:${hook}" )
+  eval "$hook(){ sandbox $cmd; $hook \$@ ; }"
+}
+
+# automatically add hooks for shims of virtualenvs, e.g. pyenv, rbenv, etc
+# optionally pass the shim directory, assumed to be $HOME/.<command>/shims
+function sandbox_hook_shims(){
+  local cmd=$1
+  local dir="${2:-$HOME/.$1/shims}"
+  if test -d $dir; then
+    for shim in $(ls $dir); do
+      sandbox_hook $1 $shim
+    done
+  fi
+}
+
+source "$RC_FILE"
+
+# create hooks for the sandbox names themselves
+function sandbox_initialise(){
+  local funcs="$( cat $RC_FILE | sed 's/#.*$//g' | GREP_OPTIONS= grep -o 'sandbox_init_[^(]\+' )"
+  while read f; do
+    local cmd=$(echo $f | sed s/sandbox_init_//)
+    sandbox_hook $cmd $cmd;
+  done < <(echo "$funcs")
+}
+
+sandbox_initialise

--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -16,6 +16,7 @@ local COLOR_RESET="%{$reset_color%}"
 local COLOR_GIT_DIRTY="%{$fg_bold[green]%}"
 local COLOR_GIT_CLEAN="%{$fg_bold[red]%}"
 local COLOR_DIRECTORY_NAME="%{$fg_bold[white]%}"
+local COLOR_NEED_PUSH="%{$fg_bold[yellow]%}"
 local COLOR_PREFIX="%{$fg_bold[white]%}"
 local PREFIX_SYMBOL="▲"
 local PREFIX="$COLOR_PREFIX$PREFIX_SYMBOL$COLOR_RESET"
@@ -38,9 +39,9 @@ git_dirty() {
   else
     if [[ $($git status --porcelain) == "" ]]
     then
-      echo "[$COLOR_GIT_DIRTY$(git_prompt_info)$COLOR_RESET] "
+      echo "[$COLOR_GIT_DIRTY$(git_prompt_info)$COLOR_RESET]"
     else
-      echo "[$COLOR_GIT_CLEAN$(git_prompt_info)$COLOR_RESET] "
+      echo "[$COLOR_GIT_CLEAN$(git_prompt_info)$COLOR_RESET]"
     fi
   fi
 }
@@ -51,22 +52,22 @@ git_prompt_info () {
  echo "${ref#refs/heads/}"
 }
 
-# # This assumes that you always have an origin named `origin`, and that you only
-# # care about one specific origin. If this is not the case, you might want to use
-# # `$git cherry -v @{upstream}` instead.
-# need_push () {
-#   if [ $($git rev-parse --is-inside-work-tree 2>/dev/null) ]
-#   then
-#     number=$($git cherry -v origin/$(git symbolic-ref --short HEAD) 2>/dev/null | wc -l | bc)
+# This assumes that you always have an origin named `origin`, and that you only
+# care about one specific origin. If this is not the case, you might want to use
+# `$git cherry -v @{upstream}` instead.
+need_push () {
+  if [ $($git rev-parse --is-inside-work-tree 2>/dev/null) ]
+  then
+    COUNT=$($git cherry -v origin/$(git symbolic-ref --short HEAD) 2>/dev/null | wc -l | bc)
 
-#     if [[ $number == 0 ]]
-#     then
-#       echo " "
-#     else
-#       echo " with %{$fg_bold[magenta]%}$number unpushed$COLOR_RESET"
-#     fi
-#   fi
-# }
+    if [[ $COUNT == 0 ]]
+    then
+      echo " "
+    else
+      echo " ($COLOR_NEED_PUSH$COUNT$COLOR_RESET) "
+    fi
+  fi
+}
 
 directory_name() {
   echo "$COLOR_DIRECTORY_NAME%1/%\\$COLOR_RESET"
@@ -84,7 +85,7 @@ directory_name() {
 #   fi
 # }
 
-export PROMPT=$'$PREFIX $(directory_name) $(git_dirty)'
+export PROMPT=$'$PREFIX $(directory_name) $(git_dirty)$(need_push)'
 
 set_prompt () {
   export RPROMPT="%{$fg_bold[cyan]%}$COLOR_RESET"


### PR DESCRIPTION
⏱️ Timing w/:

- `nvm` assumption
- `ruby` lazy load
- `python` lazy load
- `BREW_PREFIX` export instead of `$(brew --prefix)`

```bash
▲ .dotfiles [refactor/bin] zshTimer
        1.16 real         0.47 user         0.67 sys
        1.13 real         0.47 user         0.66 sys
        1.14 real         0.47 user         0.65 sys
        1.12 real         0.46 user         0.65 sys
        1.12 real         0.46 user         0.64 sys
        1.13 real         0.46 user         0.65 sys
        1.20 real         0.47 user         0.71 sys
        1.11 real         0.46 user         0.64 sys
        1.17 real         0.48 user         0.68 sys
        1.13 real         0.46 user         0.66 sys
```

Not bad for an ol’ laptop. 💻️