### PR TITLE
✨  config_files “dynamically” hard-code (~0.35s) [build]

### DIFF
--- a/symlinks/zshrc.symlink
+++ b/symlinks/zshrc.symlink
@@ -18,40 +18,74 @@ then
   source ~/.zshrc.private
 fi
 
-# 💽️ get all zsh files
-typeset -U config_files
-config_files=($ZSH/**/*.zsh)
+# # 💽️ get all zsh files
+# #
+# # 🔥️ Hard-code the `config_files` since these rarely change
+# #    1) Uncomment => Run the `config_files` search
+# #    2) Manually populate the hard-coded `config_files` variable
+# # 💪️ Gains:
+# #    BEFORE: 0.55 sys
+# #    AFTER:  0.23 sys
+# #
+
+# typeset -U config_files
+# config_files=($ZSH/**/*.zsh)
+# echo $config_files
+
+config_files=(
+  # paths
+  $ZSH/config/go.path.zsh
+  $ZSH/config/homebrew.path.zsh
+  $ZSH/config/java.path.zsh
+  $ZSH/config/nvm.path.zsh
+  $ZSH/config/python.path.zsh
+  $ZSH/config/rust.path.zsh
+  $ZSH/config/system.path.zsh
+  $ZSH/config/yarn.path.zsh
+  # !paths !completion
+  $ZSH/config/database.alias.zsh
+  $ZSH/config/docker.alias.zsh
+  $ZSH/config/git.alias.zsh
+  $ZSH/config/node.alias.zsh
+  $ZSH/config/npm.alias.zsh
+  $ZSH/config/ruby.alias.zsh
+  $ZSH/config/system.alias.zsh
+  $ZSH/config/system.env.zsh
+  $ZSH/config/system.grc.zsh
+  $ZSH/config/system.keys.zsh
+  $ZSH/config/xcode.alias.zsh
+  $ZSH/config/yarn.alias.zsh
+  $ZSH/config/zsh.alias.zsh
+  $ZSH/symlinks/rbenv.zsh
+  $ZSH/zsh/config.zsh
+  $ZSH/zsh/fpath.zsh
+  $ZSH/zsh/plugins/history-substring-search.plugin.zsh
+  $ZSH/zsh/prompt.zsh
+  $ZSH/zsh/window.zsh
+  # completion
+  $ZSH/config/git.completion.zsh
+  $ZSH/config/nvm.completion.zsh
+  $ZSH/config/ruby.completion.zsh
+  $ZSH/config/zsh.completion.zsh
+)
 
 # 🗺️ load: path
 for file in ${(M)config_files:#*/*.path.zsh}
 do
-  # timer=$(($(gdate +%s%N)/1000000))
   source $file
-  # now=$(($(gdate +%s%N)/1000000))
-  # elapsed=$(($now-$timer))
-  # echo $elapsed":" $file
-
 done
 
 # 🛁️ load: everything (except: path, completion, & sandboxd)
 for file in ${${${config_files:#*/*.path.zsh}:#*/*.completion.zsh}:#*/sandboxd.plugin.zsh}
 do
-  # timer=$(($(gdate +%s%N)/1000000))
   source $file
-  # now=$(($(gdate +%s%N)/1000000))
-  # elapsed=$(($now-$timer))
-  # echo $elapsed":" $file
 done
 
 # 🧭️ load: completion (after autocomplete loads)
 autoload -Uz compinit && compinit
 for file in ${(M)config_files:#*/*.completion.zsh}
 do
-  # timer=$(($(gdate +%s%N)/1000000))
   source $file
-  # now=$(($(gdate +%s%N)/1000000))
-  # elapsed=$(($now-$timer))
-  # echo $elapsed":" $file
 done
 
 unset config_files


### PR DESCRIPTION
Not as cool? Yes. 😬️
Much faster? Yes. 🤔️
Ship?        Yes. 😃️

- 🥇️ `0.35s` (`-0.4`; `-0.8`) #3
- 🥈️ `0.75s` (`-0.4`) #2
- 🥉️ `1.15s` #1

```bash
▲ .dotfiles [refactor/zsh-ii] zshTimer
        0.35 real         0.13 user         0.24 sys
        0.36 real         0.13 user         0.24 sys
        0.35 real         0.13 user         0.24 sys
        0.59 real         0.16 user         0.30 sys
        0.37 real         0.13 user         0.25 sys
        0.35 real         0.13 user         0.24 sys
        0.40 real         0.13 user         0.25 sys
        0.35 real         0.13 user         0.24 sys
        0.35 real         0.13 user         0.23 sys
        0.34 real         0.13 user         0.24 sys
▲ .dotfiles [refactor/zsh-ii] nvm -v
🥪️ sandboxing nvm ...
yarn -0.39.0
▲ .dotfiles [refactor/zsh-ii] yarn -v
🥪️ sandboxing yarn ...
1.22.17
▲ .dotfiles [refactor/zsh-ii] c
▲ .dotfiles [refactor/zsh-ii] j
▲ .dotfiles [refactor/zsh-ii] pyenv -v
🥪️ sandboxing pyenv ...
pyenv 2.2.2
▲ .dotfiles [refactor/zsh-ii] node -v
v16.13.1
▲ .dotfiles [refactor/zsh-ii] ruby -v
🥪️ sandboxing ruby ...
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]
```