### PR TITLE
💥  config.setup.zsh ~0.19s (0.09usr|0.10sys) [build]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # 💽️ @jeromefitz/dotfiles
 
-A set of scripts to set up and keep a machine up-to-date (`macos`). Via `zsh` and `Homebrew`. 🍻️
-
-Latest iteration heavy from [`rholman`](#%EF%B8%8F-references) && [`jacobwgillespie`](#%EF%B8%8F-references). 🙇
+A set of scripts (`zsh` && `Homebrew`) to set up and keep a machine up-to-date (`macos`).
 
 ## ⬇️ Download
 
@@ -11,9 +9,9 @@ Latest iteration heavy from [`rholman`](#%EF%B8%8F-references) && [`jacobwgilles
 📝️ _**Note:** You’ll need to set the version._
 
 ```sh
-curl -LJO -k https://github.com/JeromeFitz/dotfiles/archive/v1.0.0.tar.gz
+curl -LJO -k https://github.com/JeromeFitz/dotfiles/archive/v2.0.0.tar.gz
 mkdir -p ~/.dotfiles
-tar -xf dotfiles-1.0.0.tar.gz -C ~/.dotfiles
+tar -xf dotfiles-2.0.0.tar.gz -C ~/.dotfiles
 ```
 
 :octocat: **Git installed?**
@@ -46,6 +44,8 @@ Prompt for `git`: `username|authorname|authoremail`
 Sets up `gitconfig.private.symlink` which is included w/in `gitconfig.symlink` and not attributed to repo. 🙈️
 
 ### 🔗️ symlinks
+
+Will set up `~/.[xyz]` with:
 
 ```sh
 └─── symlinks
@@ -81,25 +81,34 @@ Will uninstall those extra `brew|cask|tap|...`.
 
 ### 🛠️ zsh configuration
 
-Order of `source` b/c `nvm` is fickle:
-
 ```sh
 └─── config
+│   │   sandboxd.plugin.zsh
 │   │   *.path.zsh
 │   │   *.!completion.zsh
 │   │   *.completion.zsh
-│   │   nvm.*.zsh
 ```
 
-#### 😱️ oh-my-zsh
+#### 🔥️ config.setup.zsh
 
-I teeter back-and-forth on using `oh-my-zsh` and not.
+Setup file that will cycle through the above to generate a hard-code list to `source` from that you put into `zshrc.symlink`.
 
-To be completely up-front, I usually still clone `oh-my-zsh` into `./.oh-my-zsh` and via `.zshrc.private.symlink` will include specific functions. (`git`, I am specifically talking about the `git` plugin.)
+By not `typeset`’ing and looping through on `zsh` init we save `~0.56s`. 😅️
+
+📝️ _**Note:** If we ran this dynamically first, and cached for subsequent sessions that could be a down the line trade-off for proper dynamic sourcing._
+
+#### 🥪️ sandboxd
+
+Utilizes [`sandboxd`](https://github.com/benvan/sandboxd) for:
+
+- `nvm`
+- `pyenv`
+- `ruby`
 
 ### 🤓️ zsh functions
 
 > `dot` is a simple script that installs some dependencies, sets sane macOS defaults, and so on. Tweak this script, and occasionally run `dot` from time to time to keep your environment fresh and up-to-date. You can find this script in `bin/`.
+>
 > ref: [@holman/dotfiles](https://github.com/holman/dotfiles/blob/master/bin/dot)
 
 ## 📦️ other packages
@@ -117,12 +126,16 @@ This may seem a bit verbose, however, keeps things consistent:
 
 Over the years I have revamped this a bit through inspiration and sheer 🍽️ `fork`ery:
 
-- [croaky/dotfiles](https://github.com/croaky/dotfiles)
-- [thoughtbot/dotfiles](https://github.com/thoughtbot/dotfiles)
-- [thoughtbot/laptop](https://github.com/thoughtbot/laptop)h
-- [dot-local](http://robots.thoughtbot.com/manage-team-and-personal-dotfiles-together-with-rcm)
+- ~~croaky/dotfiles~~ 🪦️
+- [thoughtbot/dotfiles](https://github.com/thoughtbot/dotfiles) 🤖️
+- [thoughtbot/laptop](https://github.com/thoughtbot/laptop) 🤖️
+- [dot-local](http://robots.thoughtbot.com/manage-team-and-personal-dotfiles-together-with-rcm) 🤖️
 - [holman](https://github.com/holman/dotfiles)
 - [jacobwgillespie](https://github.com/jacobwgillespie/dotfiles)
+
+Latest iteration is specifically heavy from [`rholman`](#%EF%B8%8F-references) && [`jacobwgillespie`](#%EF%B8%8F-references). 🏆️
+
+## 🔒️ \*.private
 
 I personally prefer `.private` instead of `.local` and have a separate 🔒️ [repo](https://github.com/JeromeFitz/dotfiles-private) 🔒️ that symlinks (& sources from there...):
 

--- a/symlinks/zshrc.symlink
+++ b/symlinks/zshrc.symlink
@@ -18,77 +18,53 @@ then
   source ~/.zshrc.private
 fi
 
-# # 💽️ get all zsh files
 # #
 # # 🔥️ Hard-code the `config_files` since these rarely change
-# #    1) Uncomment => Run the `config_files` search
-# #    2) Manually populate the hard-coded `config_files` variable
+# #    1) Uncomment => source ... config.setup.zsh
+# #    2) Manually populate the files below/ re-comment out
+# #    3) Replace filepath w/ $ZSH
+# #
 # # 💪️ Gains:
 # #    BEFORE: 0.55 sys
-# #    AFTER:  0.23 sys
+# #    AFTER:  0.10 sys (-0.45)
 # #
+# source $ZSH/zsh/config.setup.zsh
 
-# typeset -U config_files
-# config_files=($ZSH/**/*.zsh)
-# echo $config_files
-
-config_files=(
-  # paths
-  $ZSH/config/go.path.zsh
-  $ZSH/config/homebrew.path.zsh
-  $ZSH/config/java.path.zsh
-  $ZSH/config/nvm.path.zsh
-  $ZSH/config/python.path.zsh
-  $ZSH/config/rust.path.zsh
-  $ZSH/config/system.path.zsh
-  $ZSH/config/yarn.path.zsh
-  # !paths !completion
-  $ZSH/config/database.alias.zsh
-  $ZSH/config/docker.alias.zsh
-  $ZSH/config/git.alias.zsh
-  $ZSH/config/node.alias.zsh
-  $ZSH/config/npm.alias.zsh
-  $ZSH/config/ruby.alias.zsh
-  $ZSH/config/system.alias.zsh
-  $ZSH/config/system.env.zsh
-  $ZSH/config/system.grc.zsh
-  $ZSH/config/system.keys.zsh
-  $ZSH/config/xcode.alias.zsh
-  $ZSH/config/yarn.alias.zsh
-  $ZSH/config/zsh.alias.zsh
-  $ZSH/symlinks/rbenv.zsh
-  $ZSH/zsh/config.zsh
-  $ZSH/zsh/fpath.zsh
-  $ZSH/zsh/plugins/history-substring-search.plugin.zsh
-  $ZSH/zsh/prompt.zsh
-  $ZSH/zsh/window.zsh
-  # completion
-  $ZSH/config/git.completion.zsh
-  $ZSH/config/nvm.completion.zsh
-  $ZSH/config/ruby.completion.zsh
-  $ZSH/config/zsh.completion.zsh
-)
-
-# 🗺️ load: path
-for file in ${(M)config_files:#*/*.path.zsh}
-do
-  source $file
-done
-
-# 🛁️ load: everything (except: path, completion, & sandboxd)
-for file in ${${${config_files:#*/*.path.zsh}:#*/*.completion.zsh}:#*/sandboxd.plugin.zsh}
-do
-  source $file
-done
-
-# 🧭️ load: completion (after autocomplete loads)
+# 🗺️  path
+source $ZSH/config/go.path.zsh
+source $ZSH/config/homebrew.path.zsh
+source $ZSH/config/java.path.zsh
+source $ZSH/config/nvm.path.zsh
+source $ZSH/config/python.path.zsh
+source $ZSH/config/rust.path.zsh
+source $ZSH/config/system.path.zsh
+source $ZSH/config/yarn.path.zsh
+# 🛁️  * (!path|completion|sandboxd|config.setup)
+source $ZSH/config/database.alias.zsh
+source $ZSH/config/docker.alias.zsh
+source $ZSH/config/git.alias.zsh
+source $ZSH/config/node.alias.zsh
+source $ZSH/config/npm.alias.zsh
+source $ZSH/config/ruby.alias.zsh
+source $ZSH/config/system.alias.zsh
+source $ZSH/config/system.env.zsh
+source $ZSH/config/system.grc.zsh
+source $ZSH/config/system.keys.zsh
+source $ZSH/config/xcode.alias.zsh
+source $ZSH/config/yarn.alias.zsh
+source $ZSH/config/zsh.alias.zsh
+source $ZSH/symlinks/rbenv.zsh
+source $ZSH/zsh/config.zsh
+source $ZSH/zsh/fpath.zsh
+source $ZSH/zsh/plugins/history-substring-search.plugin.zsh
+source $ZSH/zsh/prompt.zsh
+source $ZSH/zsh/window.zsh
+# 🧭️  completion (after autocomplete loads)
 autoload -Uz compinit && compinit
-for file in ${(M)config_files:#*/*.completion.zsh}
-do
-  source $file
-done
-
-unset config_files
+source $ZSH/config/git.completion.zsh
+source $ZSH/config/nvm.completion.zsh
+source $ZSH/config/ruby.completion.zsh
+source $ZSH/config/zsh.completion.zsh
 
 # 📜️ Better history
 # Credits to https://coderwall.com/p/jpj_6q/zsh-better-history-searching-with-arrow-keys

--- a/zsh/config.setup.zsh
+++ b/zsh/config.setup.zsh
@@ -1,0 +1,27 @@
+# # 💽️ get all zsh files
+#
+# # 🍱️ SETUP: BEGIN
+typeset -U config_files
+config_files=($ZSH/**/*.zsh)
+
+echo "# 🗺️  path"
+for file in ${(M)config_files:#*/*.path.zsh}
+do
+  echo "source $file"
+done
+
+echo "# 🛁️  * (!path|completion|sandboxd|config.setup)"
+for file in ${${${${config_files:#*/*.path.zsh}:#*/*.completion.zsh}:#*/sandboxd.plugin.zsh}:#*/config.setup.zsh}
+do
+  echo "source $file"
+done
+
+echo "# 🧭️  completion (after autocomplete loads)"
+echo "autoload -Uz compinit && compinit"
+for file in ${(M)config_files:#*/*.completion.zsh}
+do
+  echo "source $file"
+done
+
+unset config_files
+# # 🍱️ SETUP: END


### PR DESCRIPTION
That’ll do 🐷️

- 🏆️ `0.19s` (`-0.16`, `-0.56`; `-0.96`) #4
- 🥇️ `0.35s` (`-0.4`; `-0.8`) #3
- 🥈️ `0.75s` (`-0.4`) #2
- 🥉️ `1.15s` #1

A bit more setup than “out-of-the-box” however the trade-off is welcomed.

📝️ README updates and code comments.

```bash
▲ .dotfiles [refactor/zsh-iii] zshTimer
        0.20 real         0.09 user         0.10 sys
        0.18 real         0.09 user         0.09 sys
        0.18 real         0.09 user         0.09 sys
        0.18 real         0.08 user         0.09 sys
        0.18 real         0.08 user         0.09 sys
        0.19 real         0.08 user         0.09 sys
        0.18 real         0.08 user         0.09 sys
        0.20 real         0.09 user         0.10 sys
        0.19 real         0.09 user         0.10 sys
        0.19 real         0.09 user         0.10 sys
▲ .dotfiles [refactor/zsh-iii] node -v
🥪️ sandboxing nvm ...
v16.13.1
▲ .dotfiles [refactor/zsh-iii] pyenv -v
🥪️ sandboxing pyenv ...
pyenv 2.2.2
▲ .dotfiles [refactor/zsh-iii] ruby -v
🥪️ sandboxing ruby ...
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]
▲ .dotfiles [refactor/zsh-iii] git --version
git version 2.34.1
hub version refs/heads/master
▲ .dotfiles [refactor/zsh-iii]
```

💥️  BREAKING CHANGE: Revamped way of sourcing for zsh (non-dynamic-dynamic)