### PR TITLE
✨  dynamically generate: config.setup.zsh [build]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # 💽️ @jeromefitz/dotfiles
 
-A set of scripts (`zsh` && `Homebrew`) to set up and keep a machine up-to-date (`macos`).
+Scripts (`zsh` && `Homebrew`) to set up and keep a machine up-to-date (`macos`).
+
+## ⏱️ Speed Test
+
+Latest on `2021-12-04`:
+
+```bash
+▲ .dotfiles [main] for i in $(seq 1 10); do /usr/bin/time zsh -i -c exit; done
+        0.19 real         0.09 user         0.10 sys
+        0.19 real         0.08 user         0.09 sys
+        0.19 real         0.09 user         0.09 sys
+        0.18 real         0.08 user         0.09 sys
+        0.19 real         0.09 user         0.10 sys
+        0.19 real         0.08 user         0.09 sys
+        0.19 real         0.09 user         0.10 sys
+        0.18 real         0.08 user         0.09 sys
+        0.19 real         0.09 user         0.09 sys
+        0.19 real         0.09 user         0.09 sys
+```
 
 ## ⬇️ Download
 
@@ -9,9 +27,9 @@ A set of scripts (`zsh` && `Homebrew`) to set up and keep a machine up-to-date (
 📝️ _**Note:** You’ll need to set the version._
 
 ```sh
-curl -LJO -k https://github.com/JeromeFitz/dotfiles/archive/v2.0.0.tar.gz
+curl -LJO -k https://github.com/JeromeFitz/dotfiles/archive/v2.1.0.tar.gz
 mkdir -p ~/.dotfiles
-tar -xf dotfiles-2.0.0.tar.gz -C ~/.dotfiles
+tar -xf dotfiles-2.1.0.tar.gz -C ~/.dotfiles
 ```
 
 :octocat: **Git installed?**
@@ -91,9 +109,19 @@ Will uninstall those extra `brew|cask|tap|...`.
 
 #### 🔥️ config.setup.zsh
 
-Setup file that will cycle through the above to generate a hard-code list to `source` from that you put into `zshrc.symlink`.
+Created/Maintained via `./scripts/zsh-config-setup`. That will cycle through the above (`path|*|completion`) to generate a hard-code list to `source` from that is pulled in via `zshrc.symlink`.
 
-By not `typeset`’ing and looping through on `zsh` init we save `~0.56s`. 😅️
+By not `typeset`’ing and looping through on `zsh` init dynamically we save `~0.56s`. 😅️
+
+These files rarely change, so we can side-step the init hit.
+
+The following can be run to keep up-to-date on any changes you make:
+
+```bash
+zsh-config-setup
+```
+
+And will also update via the `boostrap` and `dot` commands. 💯️
 
 📝️ _**Note:** If we ran this dynamically first, and cached for subsequent sessions that could be a down the line trade-off for proper dynamic sourcing._
 

--- a/bin/dot
+++ b/bin/dot
@@ -43,3 +43,6 @@ $ZSH/config/homebrew.install.sh 2>&1
 
 echo "› 💽️ install"
 $ZSH/scripts/install
+
+echo "› 🛠️ config.setup.zsh"
+$ZSH/scripts/zsh-config-setup

--- a/bin/zsh-config-setup
+++ b/bin/zsh-config-setup
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+echo "› 🛠️ config.setup.zsh"
+$ZSH/scripts/zsh-config-setup

--- a/scripts/zsh-config-setup
+++ b/scripts/zsh-config-setup
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$0")/.."
+DOTFILES_ROOT=$(pwd -P)
+
+CONFIG_SETUP_ZSH=$DOTFILES_ROOT/zsh/config.setup.zsh
+
+set -e
+
+# # 🛠️ config.setup.zsh
+# #    - Cycle through zsh files:
+# #      0) (re-)init file: config.setup.zsh
+# #      1) path
+# #      2) * (!path|completion|sandboxd|config.setup)
+# #      3) completion
+# #    - Creates `config.setup.zsh` for `zshrc.symlink` source
+# #    - Scripts to init / keep updated:
+# #       - sh ./scripts/zsh-config-setup # init
+# #       - dot # after setup + symlink
+# #       - zsh-config-setup # after setup + symlink
+# #
+# # 💪️ Gains:
+# #    BEFORE: 0.55 sys
+# #    AFTER:  0.10 sys (-0.45)
+# #
+# # 🍱️ SETUP: BEGIN
+
+# # 📝️ 0) (re-)init file
+echo "" > "$CONFIG_SETUP_ZSH"
+
+# # 🗺️ 1) path
+for file in $(find -H "$DOTFILES_ROOT" -maxdepth 2 -name '*.path.zsh' -not -path '*config.setup.zsh' | sort)
+do
+  echo "source ${file/#$DOTFILES_ROOT/\$ZSH}" >> "$CONFIG_SETUP_ZSH"
+done
+
+# # 🛁️  2) * (!path|completion|sandboxd|config.setup)
+for file in $(find -H "$DOTFILES_ROOT" -maxdepth 2 -name '*.zsh' -not -path '*.path.zsh' -not -path '*.completion.zsh' -not -path 'sandboxd.plugin.zsh' -not -path '*config.setup.zsh' | sort)
+do
+  echo "source ${file/#$DOTFILES_ROOT/\$ZSH}" >> "$CONFIG_SETUP_ZSH"
+done
+
+# # 🧭️  3) completion (after autocomplete loads)
+echo "autoload -Uz compinit && compinit" >> "$CONFIG_SETUP_ZSH"
+for file in $(find -H "$DOTFILES_ROOT" -maxdepth 2 -name '*.completion.zsh' -not -path '*config.setup.zsh' | sort)
+do
+  echo "source ${file/#$DOTFILES_ROOT/\$ZSH}" >> "$CONFIG_SETUP_ZSH"
+done
+
+# #
+# # 🍱️ SETUP: END

--- a/symlinks/zshrc.symlink
+++ b/symlinks/zshrc.symlink
@@ -18,53 +18,11 @@ then
   source ~/.zshrc.private
 fi
 
-# #
-# # 🔥️ Hard-code the `config_files` since these rarely change
-# #    1) Uncomment => source ... config.setup.zsh
-# #    2) Manually populate the files below/ re-comment out
-# #    3) Replace filepath w/ $ZSH
-# #
-# # 💪️ Gains:
-# #    BEFORE: 0.55 sys
-# #    AFTER:  0.10 sys (-0.45)
-# #
-# source $ZSH/zsh/config.setup.zsh
-
-# 🗺️  path
-source $ZSH/config/go.path.zsh
-source $ZSH/config/homebrew.path.zsh
-source $ZSH/config/java.path.zsh
-source $ZSH/config/nvm.path.zsh
-source $ZSH/config/python.path.zsh
-source $ZSH/config/rust.path.zsh
-source $ZSH/config/system.path.zsh
-source $ZSH/config/yarn.path.zsh
-# 🛁️  * (!path|completion|sandboxd|config.setup)
-source $ZSH/config/database.alias.zsh
-source $ZSH/config/docker.alias.zsh
-source $ZSH/config/git.alias.zsh
-source $ZSH/config/node.alias.zsh
-source $ZSH/config/npm.alias.zsh
-source $ZSH/config/ruby.alias.zsh
-source $ZSH/config/system.alias.zsh
-source $ZSH/config/system.env.zsh
-source $ZSH/config/system.grc.zsh
-source $ZSH/config/system.keys.zsh
-source $ZSH/config/xcode.alias.zsh
-source $ZSH/config/yarn.alias.zsh
-source $ZSH/config/zsh.alias.zsh
-source $ZSH/symlinks/rbenv.zsh
-source $ZSH/zsh/config.zsh
-source $ZSH/zsh/fpath.zsh
-source $ZSH/zsh/plugins/history-substring-search.plugin.zsh
-source $ZSH/zsh/prompt.zsh
-source $ZSH/zsh/window.zsh
-# 🧭️  completion (after autocomplete loads)
-autoload -Uz compinit && compinit
-source $ZSH/config/git.completion.zsh
-source $ZSH/config/nvm.completion.zsh
-source $ZSH/config/ruby.completion.zsh
-source $ZSH/config/zsh.completion.zsh
+# 🛠️ config.setup.zsh
+if [[ -a $ZSH/zsh/config.setup.zsh ]]
+then
+  source $ZSH/zsh/config.setup.zsh
+fi
 
 # 📜️ Better history
 # Credits to https://coderwall.com/p/jpj_6q/zsh-better-history-searching-with-arrow-keys

--- a/zsh/config.setup.zsh
+++ b/zsh/config.setup.zsh
@@ -1,27 +1,32 @@
-# # 💽️ get all zsh files
-#
-# # 🍱️ SETUP: BEGIN
-typeset -U config_files
-config_files=($ZSH/**/*.zsh)
 
-echo "# 🗺️  path"
-for file in ${(M)config_files:#*/*.path.zsh}
-do
-  echo "source $file"
-done
-
-echo "# 🛁️  * (!path|completion|sandboxd|config.setup)"
-for file in ${${${${config_files:#*/*.path.zsh}:#*/*.completion.zsh}:#*/sandboxd.plugin.zsh}:#*/config.setup.zsh}
-do
-  echo "source $file"
-done
-
-echo "# 🧭️  completion (after autocomplete loads)"
-echo "autoload -Uz compinit && compinit"
-for file in ${(M)config_files:#*/*.completion.zsh}
-do
-  echo "source $file"
-done
-
-unset config_files
-# # 🍱️ SETUP: END
+source $ZSH/config/go.path.zsh
+source $ZSH/config/homebrew.path.zsh
+source $ZSH/config/java.path.zsh
+source $ZSH/config/nvm.path.zsh
+source $ZSH/config/python.path.zsh
+source $ZSH/config/rust.path.zsh
+source $ZSH/config/system.path.zsh
+source $ZSH/config/yarn.path.zsh
+source $ZSH/config/database.alias.zsh
+source $ZSH/config/docker.alias.zsh
+source $ZSH/config/git.alias.zsh
+source $ZSH/config/node.alias.zsh
+source $ZSH/config/npm.alias.zsh
+source $ZSH/config/ruby.alias.zsh
+source $ZSH/config/system.alias.zsh
+source $ZSH/config/system.env.zsh
+source $ZSH/config/system.grc.zsh
+source $ZSH/config/system.keys.zsh
+source $ZSH/config/xcode.alias.zsh
+source $ZSH/config/yarn.alias.zsh
+source $ZSH/config/zsh.alias.zsh
+source $ZSH/symlinks/rbenv.zsh
+source $ZSH/zsh/config.zsh
+source $ZSH/zsh/fpath.zsh
+source $ZSH/zsh/prompt.zsh
+source $ZSH/zsh/window.zsh
+autoload -Uz compinit && compinit
+source $ZSH/config/git.completion.zsh
+source $ZSH/config/nvm.completion.zsh
+source $ZSH/config/ruby.completion.zsh
+source $ZSH/config/zsh.completion.zsh


### PR DESCRIPTION
📝  README update w/ speed test

Instead of manually editing `zshrc.symlink` dynamically generate `config.setup.zsh` to be sourced through `zsh-config-setup` during `bootstrap` or `dot`.

🙈️ This does mean that we may be able to ignore `config.setup.zsh` in the repo. For now keep it. 💯 

```bash
▲ .dotfiles [main] for i in $(seq 1 10); do /usr/bin/time zsh -i -c exit; done
        0.19 real         0.09 user         0.10 sys
        0.19 real         0.08 user         0.09 sys
        0.19 real         0.09 user         0.09 sys
        0.18 real         0.08 user         0.09 sys
        0.19 real         0.09 user         0.10 sys
        0.19 real         0.08 user         0.09 sys
        0.19 real         0.09 user         0.10 sys
        0.18 real         0.08 user         0.09 sys
        0.19 real         0.09 user         0.09 sys
        0.19 real         0.09 user         0.09 sys
```