### PR TITLE
🔧 (renovate) fix dep warn; actor-based skip check [skip ci]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,15 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [":semanticCommitsDisabled"],
   "automerge": false,
-  "baseBranches": ["main"],
+  "baseBranchPatterns": ["main"],
   "branchPrefix": "deps/",
-  "commitMessage": "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}}",
-  "commitMessageAction": "",
+  "commitMessageAction": "(deps)",
   "commitMessageExtra": "",
-  "commitMessagePrefix": "⬆️  (deps)",
+  "commitMessagePrefix": "⬆️",
   "commitMessageSuffix": "",
   "commitMessageTopic": " {{depName}}@{{#if isPinDigest}}{{{newDigest}}}{{else}}{{#if isMajor}}{{{newVersion}}}{{else}}{{#if isSingleVersion}}{{{newVersion}}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigest}}}{{/if}}{{/if}}{{/if}}{{/if}}",
-  "dependencyDashboard": false,
+  "dependencyDashboard": true,
   "labels": ["📦️ Dependencies"],
   "packageRules": [
     {
@@ -27,29 +26,32 @@
       "minimumReleaseAge": "1 day"
     },
     {
-      "commitMessagePrefix": "👷  (actions)",
-      "commitMessageExtra": "{{depName}}@{{#if isPinDigest}}{{{newDigest}}}{{else}}{{#if isMajor}}{{{newVersion}}}{{else}}{{#if isSingleVersion}}{{{newVersion}}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigest}}}{{/if}}{{/if}}{{/if}}{{/if}}",
-      "commitMessageTopic": " {{depName}}",
-      "groupName": "github actions :octocat: ...",
+      "commitMessageAction": "(actions)",
+      "commitMessagePrefix": "👷",
+      "groupName": "github actions :octocat:",
       "groupSlug": "github-actions",
-      "matchPackagePatterns": ["^actions"]
+      "matchPackageNames": ["/^actions/"]
     },
     {
       "allowedVersions": "<25",
-      "commitMessagePrefix": "📦  (deps-dev)",
+      "commitMessageAction": "(deps-dev)",
+      "commitMessagePrefix": "📦",
       "matchDepTypes": ["devDependencies", "dependencies"],
       "matchPackageNames": ["@types/node"]
     },
     {
-      "commitMessagePrefix": "⬆️  (deps)",
+      "commitMessageAction": "(deps)",
+      "commitMessagePrefix": "⬆️",
       "matchDepTypes": ["dependencies"]
     },
     {
-      "commitMessagePrefix": "📦  (deps-peer)",
+      "commitMessageAction": "(deps-peer)",
+      "commitMessagePrefix": "📦",
       "matchDepTypes": ["peerDependencies"]
     },
     {
-      "commitMessagePrefix": "📦  (deps-dev)",
+      "commitMessageAction": "(deps-dev)",
+      "commitMessagePrefix": "📦",
       "matchDepTypes": ["devDependencies"]
     },
     {
@@ -63,7 +65,6 @@
   "prFooter": "<!-- COMMIT_BODY_TEXT_END -->",
   "prHeader": "<!-- COMMIT_BODY_TEXT_BEGIN -->",
   "prHourlyLimit": 2,
-  "prTitle": "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}}",
   "rebaseWhen": "conflicted",
   "semanticCommits": "disabled"
 }

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   pull:
     name: "👷️  CI"
-    if: (contains(github.event.head_commit.message, '[b]') || github.ref == 'refs/heads/main') && !contains(github.event.head_commit.message, '[skip ci]')
+    if: (contains(github.event.head_commit.message, '[b]') || (github.ref == 'refs/heads/main' && github.actor != 'renovate[bot]')) && !contains(github.event.head_commit.message, '[skip ci]')
     timeout-minutes: 20
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Summary

- Remove deprecated `commitMessage` and `prTitle` top-level fields
- Restructure commit message components: `commitMessagePrefix` → gitmoji, `commitMessageAction` → scope
- Simplify GitHub Actions package rule (drop redundant `commitMessageExtra` and `commitMessageTopic` overrides)
- `baseBranches` → `baseBranchPatterns`, `matchPackagePatterns` → `matchPackageNames` (Renovate migrations)
- Enable `dependencyDashboard` temporarily to surface any config errors visibly
- Add actor-based CI skip to `push.yml`

## Push job condition

```
(contains('[b]') || (on main && not renovate[bot])) && !contains('[skip ci]')
```

| Who | Branch | `[b]`? | `[skip ci]`? | Runs? |
|---|---|---|---|---|
| Human | main | no | no | ✓ |
| Human | main | no | yes | ✗ |
| Human | main | yes | no | ✓ |
| Human | feature | yes | no | ✓ |
| Human | feature | no | no | ✗ |
| renovate[bot] | main | no | no | ✗ |
| renovate[bot] | main | yes | no | ✓ |

## Test plan

- [x] Renovate Dependency Dashboard issue appears (confirms config is valid)
- [x] Next Renovate PR merging to main skips the push job
- [x] Manually editing a Renovate PR title to include `[b]` causes the push job to run on merge